### PR TITLE
Add initial sketch for the pipeline runner

### DIFF
--- a/pipeline/Makefile
+++ b/pipeline/Makefile
@@ -1,0 +1,48 @@
+#!/usr/bin/make -rRf
+
+all: run_A34048
+
+clean:
+	rm -rf $(OUTPUT)
+
+# Specify the bash shell
+SHELL := /bin/bash -o pipefail
+
+##============================================================================
+## Targets to run the existing workflow from end to end
+##============================================================================
+
+# Set up directories here
+FUSEBENCH = ~/fusebench/
+DATA = ~/fusebench_scratch/datasets/
+OUTPUT = ~/fusebench_scratch/results/
+
+run_A34048: \
+	$(OUTPUT)/A34048.pavfinder.bedpe \
+	$(OUTPUT)/A34048.ericscript.bedpe \
+	$(OUTPUT)/A34048.fusioncatcher.bedpe
+
+	# $(OUTPUT)/A34048.defuse.bedpe \
+
+# Convert raw output to BEDPE
+$(OUTPUT):
+	mkdir -p $@
+
+# Copy in PAVfinder results
+$(OUTPUT)/A34048.pavfinder.bedpe: $(DATA)/aml_cell_line_examples/pavfinder/A34048.events.bedpe $(OUTPUT)
+	cp $< $@
+
+# Convert DEfuse results
+#$(OUTPUT)/A34048.defuse.bedpe: $(DATA)/aml_cell_line_examples/defuse/A34048/results.classify.tsv
+#	Rscript $(FUSEBENCH)defuse_to_bedpe_parser.R $<
+
+# Convert ERICscript results
+$(OUTPUT)/A34048.ericscript.bedpe: $(DATA)/aml_cell_line_examples/ericscript/A34048/MOLM13_A34048.results.filtered.tsv
+	python $(FUSEBENCH)ericscript_to_bedpe.py -i $< -o $@
+
+# Convert fusioncatcher results
+$(OUTPUT)/A34048.fusioncatcher.bedpe: $(DATA)/aml_cell_line_examples/fusioncatcher/A34048/final-list_candidate-fusion-genes.GRCh37.txt
+	python $(FUSEBENCH)/fusioncatcher_to_bedpe.py -i $< -o $@
+
+# Convert STARfusion results
+# Also not working at present b/c of the Oncofuse annotations

--- a/pipeline/Makefile
+++ b/pipeline/Makefile
@@ -17,12 +17,10 @@ FUSEBENCH = ~/fusebench/
 DATA = ~/fusebench_scratch/datasets/
 OUTPUT = ~/fusebench_scratch/results/
 
-run_A34048: \
-	$(OUTPUT)/A34048.pavfinder.bedpe \
-	$(OUTPUT)/A34048.ericscript.bedpe \
-	$(OUTPUT)/A34048.fusioncatcher.bedpe
+run_A34048: run_validator
 
-	# $(OUTPUT)/A34048.defuse.bedpe \
+# $(OUTPUT)/A34048.defuse.bedpe \
+# $(OUTPUT)/A34048.star_fusion.bedpe
 
 # Convert raw output to BEDPE
 $(OUTPUT):
@@ -30,7 +28,7 @@ $(OUTPUT):
 
 # Copy in PAVfinder results
 $(OUTPUT)/A34048.pavfinder.bedpe: $(DATA)/aml_cell_line_examples/pavfinder/A34048.events.bedpe $(OUTPUT)
-	cp $< $@
+	cat $< | sed s/#chrom/chrom/ > $@
 
 # Convert DEfuse results
 #$(OUTPUT)/A34048.defuse.bedpe: $(DATA)/aml_cell_line_examples/defuse/A34048/results.classify.tsv
@@ -46,3 +44,12 @@ $(OUTPUT)/A34048.fusioncatcher.bedpe: $(DATA)/aml_cell_line_examples/fusioncatch
 
 # Convert STARfusion results
 # Also not working at present b/c of the Oncofuse annotations
+
+# Run the validator on all the existing files
+%.bedpe.validated: %.bedpe
+	python $(FUSEBENCH)/validate_bedpe.py -i $< > $@
+
+run_validator: \
+	$(OUTPUT)/A34048.fusioncatcher.bedpe.validated \
+	$(OUTPUT)/A34048.ericscript.bedpe.validated \
+	$(OUTPUT)/A34048.pavfinder.bedpe.validated


### PR DESCRIPTION
This Makefile currently runs the converters for three tools for a single replicate. 

It's mostly intended as an example for now - I'm not sure this is the right way to wrap things up - might be simpler to just have a simpler wrapper.